### PR TITLE
Update Lexer.java

### DIFF
--- a/core/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
+++ b/core/src/main/java/com/alibaba/druid/sql/parser/Lexer.java
@@ -1548,7 +1548,7 @@ public class Lexer {
                         if (charAt(pos + 1) == '*') {
                             token = Token.BARBAR;
                             break;
-                        }                        
+                        }
                         scanChar();
                         token = Token.BARBARSLASH;
                     } else {


### PR DESCRIPTION
处理druid解析例如下面sql报错的问题：select id||/\*用户id\*/name from user;  ||和/之间没有空格的话会解析报错，这种sql在oracle中是正常执行的